### PR TITLE
return zero tensor instead of tensor of size zero from stereo loss

### DIFF
--- a/jtnn/jtnn_vae.py
+++ b/jtnn/jtnn_vae.py
@@ -146,7 +146,7 @@ class JTNNVAE(nn.Module):
             labels.append( (cands.index(mol_tree.smiles3D), len(cands)) )
 
         if len(labels) == 0: 
-            return create_var(torch.Tensor(0)), 1.0
+            return create_var(torch.zeros(1)), 1.0
 
         batch_idx = create_var(torch.LongTensor(batch_idx))
         stereo_cands = self.mpn(mol2graph(stereo_cands))

--- a/jtnn/jtprop_vae.py
+++ b/jtnn/jtprop_vae.py
@@ -153,7 +153,7 @@ class JTPropVAE(nn.Module):
             labels.append( (cands.index(mol_tree.smiles3D), len(cands)) )
 
         if len(labels) == 0: 
-            return create_var(torch.Tensor(0)), 1.0
+            return create_var(torch.zeros(1)), 1.0
 
         batch_idx = create_var(torch.LongTensor(batch_idx))
         stereo_cands = self.mpn(mol2graph(stereo_cands))


### PR DESCRIPTION
This seemed like a bug to me. Was the intention to return a zero tensor opposed to a tensor of size zero?

 I think this addresses this issue. https://github.com/wengong-jin/icml18-jtnn/issues/7